### PR TITLE
Bugfixes and Improvements

### DIFF
--- a/src/clamd/__init__.py
+++ b/src/clamd/__init__.py
@@ -166,11 +166,13 @@ class ClamdNetworkSocket(object):
         finally:
             self._close_socket()
 
-    def instream(self, buff):
+    def instream(self, buff, max_chunk_size=1024):
         """
         Scan a buffer
 
         buff  filelikeobj: buffer to scan
+        max_chunk_size int: Maximum size of chunk to send to clamd in bytes
+          MUST be < StreamMaxLength in /etc/clamav/clamd.conf
 
         return:
           - (dict): {filename1: ("virusname", "status")}
@@ -184,12 +186,10 @@ class ClamdNetworkSocket(object):
             self._init_socket()
             self._send_command('INSTREAM')
 
-            max_chunk_size = 1024  # MUST be < StreamMaxLength in /etc/clamav/clamd.conf
-
             chunk = buff.read(max_chunk_size)
             while chunk:
                 size = struct.pack(b'!L', len(chunk))
-                self.clamd_socket.send(size + chunk)
+                self.clamd_socket.sendall(size + chunk)
                 chunk = buff.read(max_chunk_size)
 
             self.clamd_socket.send(struct.pack(b'!L', 0))

--- a/src/clamd/__init__.py
+++ b/src/clamd/__init__.py
@@ -192,7 +192,7 @@ class ClamdNetworkSocket(object):
                 self.clamd_socket.sendall(size + chunk)
                 chunk = buff.read(max_chunk_size)
 
-            self.clamd_socket.send(struct.pack(b'!L', 0))
+            self.clamd_socket.sendall(struct.pack(b'!L', 0))
 
             result = self._recv_response()
 

--- a/src/clamd/__init__.py
+++ b/src/clamd/__init__.py
@@ -63,8 +63,8 @@ class ClamdNetworkSocket(object):
         """
         try:
             self.clamd_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self.clamd_socket.connect((self.host, self.port))
             self.clamd_socket.settimeout(self.timeout)
+            self.clamd_socket.connect((self.host, self.port))
 
         except socket.error:
             e = sys.exc_info()[1]

--- a/src/clamd/__init__.py
+++ b/src/clamd/__init__.py
@@ -231,7 +231,7 @@ class ClamdNetworkSocket(object):
             concat_args = ' ' + ' '.join(args)
 
         cmd = 'n{cmd}{args}\n'.format(cmd=cmd, args=concat_args).encode('utf-8')
-        self.clamd_socket.send(cmd)
+        self.clamd_socket.sendall(cmd)
 
     def _recv_response(self):
         """

--- a/src/clamd/__init__.py
+++ b/src/clamd/__init__.py
@@ -63,6 +63,9 @@ class ClamdNetworkSocket(object):
         """
         try:
             self.clamd_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            # Set timeout prior to connecting to ensure that an initial
+            # connection timeout will respect the setting regardless of OS.
+            # https://docs.python.org/3/library/socket.html#timeouts-and-the-connect-method
             self.clamd_socket.settimeout(self.timeout)
             self.clamd_socket.connect((self.host, self.port))
 


### PR DESCRIPTION
A few bugfixes and improvements:

* Allow specifying max chunk size. In the case of smaller files it can make sense to send them in a single chunk
* Switch socket calls from `send` to `sendall`. This ensures that the entire message is pushed in the socket call. In our use case, NOT using `sendall` caused an issue when using `clamd` in association with `gevent`, since each socket message may or may not have pushed the full chunk, and they are working cooperatively. Aside from this use case, it also proved to be a more efficient way to send the socket messages.
* Set timeout prior to connection. This ensures that if the server is not available for some reason, timeout will be respected during initial connection.